### PR TITLE
Fix/reviewer issues

### DIFF
--- a/app/assets/javascripts/nodes.coffee
+++ b/app/assets/javascripts/nodes.coffee
@@ -71,6 +71,7 @@ $ ->
       'data'    : { 'node' : { 'title' : 'New node', 'parent_id' : selected , 'prot_id' : prot_id , 'new_position' : 0 , 'body' : "本文" } },
       'url'     : "/prots/#{REGISTRY.prot_id}/nodes.json",
       'success' : (res) ->
+        res.data = "本文"
         selected = jstree.create_node(selected, res)
         jstree.edit(selected) if (selected)
     })

--- a/app/assets/stylesheets/node.css.erb
+++ b/app/assets/stylesheets/node.css.erb
@@ -7,6 +7,10 @@ body {
   background-color: #fdfdfd !important;
 }
 
+ul {
+  list-style: none;
+}
+
 .box11{
     padding: 0.5em 1em;
     margin: 2em 0;
@@ -185,4 +189,11 @@ body {
 
 .alert {
   margin-bottom: 0px !important;
+}
+
+#error_explanation {
+  color: #721c24;
+  background-color: #f8d7da;
+  border-color: #f5c6cb;
+  border-radius: 10px;
 }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,6 +39,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/spec/features/user.spec.rb
+++ b/spec/features/user.spec.rb
@@ -21,7 +21,6 @@ RSpec.feature 'ユーザー機能', type: :feature do
     fill_in 'パスワード', with: 'subrosubro'
     fill_in '確認用パスワード', with: 'subrosubro'
 
-    # 保留
     expect { click_button 'Sign up' }.to change { ActionMailer::Base.deliveries.size }.by(1)
     expect(page).to have_content '本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください'
 
@@ -35,5 +34,14 @@ RSpec.feature 'ユーザー機能', type: :feature do
     fill_in 'メールアドレス', with: 'subro@subro.com'
     fill_in 'パスワード', with: 'subrosubro'
     click_button 'Log in'
+  end
+
+  scenario 'ログインテスト' do
+    visit '/users/sign_in'
+    fill_in 'メールアドレス', with: 'taro@taro.com'
+    fill_in 'パスワード', with: 'tarotarotaro'
+    click_button 'Log in'
+    expect(page).to have_content 'ログインしました。'
+    expect(page).to have_content 'taro'
   end
 end


### PR DESCRIPTION
ノード新規作成時本文がnullになるバグを解消
サインアップ時のエラーメッセージを赤い枠で囲う
エラーメッセージのリストスタイルを全て除去