### PR TITLE
Fix/separate prot destroy

### DIFF
--- a/app/controllers/prot_genres_controller.rb
+++ b/app/controllers/prot_genres_controller.rb
@@ -1,0 +1,7 @@
+class ProtGenresController < ApplicationController
+  def destroy
+    @prot_genres = ProtGenre.find_by(genre_id: params[:genre_id], prot_id: params[:id])
+    @prot_genres.destroy if @prot_genres.prot.user == current_user
+    redirect_to edit_prot_path(params[:id])
+  end
+end

--- a/app/controllers/prot_media_types_controller.rb
+++ b/app/controllers/prot_media_types_controller.rb
@@ -1,0 +1,8 @@
+class ProtMediaTypesController < ApplicationController
+
+  def destroy
+    @prot_media_types = ProtMediaType.find_by(media_type_id: params[:media_type_id], prot_id: params[:id])
+    @prot_media_types.destroy if @prot_media_types.prot.user == current_user
+    redirect_to edit_prot_path(params[:id])
+  end
+end

--- a/app/controllers/prots_controller.rb
+++ b/app/controllers/prots_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProtsController < ApplicationController
-  before_action :set_prot, only: %i[show edit update destroy]
+  before_action :set_prot, only: %i[show edit update destroy children]
   before_action :authenticate_user!, except: %i[index]
   before_action :correct_user_check, only: %i[edit update destroy]
   before_action :private_prot_protect, only: %i[show edit update destroy]
@@ -62,20 +62,9 @@ class ProtsController < ApplicationController
   end
 
   def destroy
-    if params[:genre_id]
-      @prot.prot_genres.find_by(genre_id: params[:genre_id]).destroy
-      flash[:success] = 'ジャンルの削除に成功しました'
-      redirect_to edit_prot_path
-
-    elsif params[:media_type_id]
-      @prot.prot_media_types.find_by(media_type_id: params[:media_type_id]).destroy
-      flash[:success] = 'メディアの削除に成功しました'
-      redirect_to edit_prot_path
-    else
-      @prot.destroy
-      flash[:success] = 'プロットの削除に成功しました'
-      redirect_to root_path
-    end
+    @prot.destroy
+    flash[:success] = 'プロットの削除に成功しました'
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/prots_controller.rb
+++ b/app/controllers/prots_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProtsController < ApplicationController
-  before_action :set_prot, only: %i[show edit update destroy children]
+  before_action :set_prot, only: %i[show edit update destroy]
   before_action :authenticate_user!, except: %i[index]
   before_action :correct_user_check, only: %i[edit update destroy]
   before_action :private_prot_protect, only: %i[show edit update destroy]

--- a/app/views/prots/_form.html.erb
+++ b/app/views/prots/_form.html.erb
@@ -65,7 +65,7 @@
   <br>
   現在の公開メディア：
   <% prot.media_types.each do |media_type| %>
-    <%= link_to media_type.name, prot_path(media_type_id: media_type.id), method: :delete, data: { confirm: "想定メディアを削除します。\n編集中の項目を先に保存してください。"} if media_type.id.present? %>
+    <%= link_to media_type.name, prot_media_type_path(media_type_id: media_type.id), method: :delete, data: { confirm: "想定メディアを削除します。\n編集中の項目を先に保存してください。"} if media_type.id.present? %>
   <% end %>
   <br>
   <br>

--- a/app/views/prots/_form.html.erb
+++ b/app/views/prots/_form.html.erb
@@ -41,7 +41,7 @@
   <br>
   現在のジャンル：
   <% prot.genres.each do |genre| %>
-    <%= link_to genre.name, prot_path(genre_id: genre.id), method: :delete, data: { confirm: "ジャンルを削除します。\n編集中の項目を先に保存してください。"} if genre.id.present? %>
+    <%= link_to genre.name, prot_genre_path(genre_id: genre.id),method: :delete, data: { confirm: "ジャンルを削除します。\n編集中の項目を先に保存してください。"} if genre.id.present? %>
   <% end %>
   <br>
   <br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Rails.application.routes.draw do
     resources :nodes, only: [:index]
   end
 
+  resources :prot_genres, only: [:destroy]
+
   resources :stars, only: %i[create destroy]
   resources :hearts, only: %i[create destroy]
   resources :goods, only: %i[create destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
   end
 
   resources :prot_genres, only: [:destroy]
+  resources :prot_media_types, only: [:destroy]
 
   resources :stars, only: %i[create destroy]
   resources :hearts, only: %i[create destroy]


### PR DESCRIPTION
prot/controller のdestroyアクションにジャンルとメディアの削除を格納していたが、セキュリティーのためにそれぞれのコントローラに分割