### PR TITLE
node showフォームを削除

### DIFF
--- a/app/assets/javascripts/nodes.coffee
+++ b/app/assets/javascripts/nodes.coffee
@@ -28,49 +28,23 @@ $(document).on 'turbolinks:load', ->
       'data'    : { 'node' : { 'body' : nodeBody } },
       'url'     : "/prots/#{REGISTRY.prot_id}/nodes/#{nodeId}.json"
     'success' : (res) ->
-      $('#saving').html('保存終了 同期中...')
+      $('#saving').html('保存終了')
       $('#saving').css('color', '#00BB00')
-      jstree.refresh()
-      # もしjstree.selected_nodeがなかったらresをget_selectする
     })
-
-  $('#edit_node').on 'click', ->
-    $('#show_node').hide()
-    $('#edit_form').show()
-    $('#edit_node').hide()
-    $('#view_node').show()
-    $('#saving').html('')
-
-  $('#view_node').on 'click', ->
-    $('#edit_form').hide()
-    $('#show_node').show()
-    $('#view_node').hide()
-    $('#edit_node').show()
-    $('#saving').html('')
 
   # nodeがselectされたときにタイトルと本文を出力する。
   $('#jstree_nodes').on "select_node.jstree", (e, node) ->
-    if $('#saving').html() == '保存終了 同期中...'
-      console.log ("同期")
-      $('#saving').html('同期しました！')
-    else if $('#saving').html() == "待機中...(同期されるまで入力操作以外行わないでください)"
-      console.log ("待機")
-      return
-    else
-      console.log ("selected")
-      body = node.node.data
-      id   = node.node.id
-      prot_id = REGISTRY.prot_id
+    body = node.node.data
+    id   = node.node.id
+    prot_id = REGISTRY.prot_id
 
-      $("#show_node").text("#{body}")
-      $("#nodeBodyFrom_#{id}").val("#{body}")
-      $(".node-form-invisible").hide()
-      $("#nodeBodyFrom_#{id}").show()
-      $("#nodeBodyFrom_#{id}").on 'input', ->
-        $('#saving').html("待機中...(同期されるまで入力操作以外行わないでください)")
-        $('#saving').css('color', 'black')
+    $(".node-form-invisible").hide()
+    $("#nodeBodyFrom_#{id}").show()
+    $("#nodeBodyFrom_#{id}").on 'input', ->
+      $('#saving').html("待機中...")
+      $('#saving').css('color', 'black')
 
-      $("#nodeBodyFrom_#{id}").on('input', _.debounce( autoSave, 1000 ))
+    $("#nodeBodyFrom_#{id}").on('input', _.debounce( autoSave, 1000 ))
 
   # ノードを移動させたときに呼ばれるイベント
   $('#jstree_nodes').on "move_node.jstree", (e, node) ->

--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -67,8 +67,7 @@ class NodesController < ApplicationController
   end
 
   def author_check
-    # current_user.prot.findでいい
-    raise StandardError if Prot.find(params[:prot_id]).user_id != current_user.id
+    raise StandardError if current_user.prots.find(params[:prot_id]).user_id != current_user.id
   end
 
   def node_params

--- a/app/views/nodes/index.html.erb
+++ b/app/views/nodes/index.html.erb
@@ -9,33 +9,26 @@
     <br>
   <div class="row">
 
-        <div class="col-6">
-          <button type="button" id="make_node" class="btn btn-success">create</button>
-          <button type="button" id="rename_node" class="btn btn-warning">rename</button>
-          <button type="button" id="delete_node" class="btn btn-danger">delete</button>
-          <button type="button" id="edit_node" class="btn btn-info">edit</button>
-          <button type="button" id="view_node" class="btn btn-info" style="display: none;">show</button>
-          <br>
-          <br>
+    <div class="col-6">
+      <button type="button" id="make_node" class="btn btn-success">create</button>
+      <button type="button" id="rename_node" class="btn btn-warning">rename</button>
+      <button type="button" id="delete_node" class="btn btn-danger">delete</button>
+      <br>
+      <br>
+      <div id="jstree_nodes" style="overflow: scroll;"></div>
+      <br>
+    </div>
 
-          <div id="jstree_nodes" style="overflow: scroll;"></div>
-          <br>
+    <div class="col-6">
+      <div id="edit_form">
+        <input type="hidden" value="" id="nodeIdHidden">
+        <div id="saving">
+          　
         </div>
-
-        <div class="col-6">
-          <!-- 本文の閲覧 -->
-          <div id="show_node" class="box11" style="word-wrap: break-word; white-space: pre-wrap; min-height: 50px;"></div>
-          <!-- 本文の編集 -->
-          <div id="edit_form" style="display: none;">
-            <input type="hidden" value="" id="nodeIdHidden">
-            <div id="saving">
-              　
-            </div>
-            <% @prot.nodes.each do |node| %>
-              <textarea id="nodeBodyFrom_<%= node.id %>" class="form-control node-form-invisible" style="display: node;" rows="80" cols="80"></textarea>
-            <% end %>
-          </div>
-        </div>
-
+        <% @prot.nodes.each do |node| %>
+          <textarea id="nodeBodyFrom_<%= node.id %>" class="form-control node-form-invisible" style="display: node;" rows="80" cols="80"><%= node.body %></textarea>
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
#64 

node_showフォームを削除することによって
オートセーブの際、ツリービューの同期を常に行う必要がなくなった。

オートセーブの問題は一応の解決をしたとして良い。

残りはwebアプリとして、他者のノードの状態を編集できないかどうか
セキュリティーの面をテストするのみである。